### PR TITLE
Impersonator tracking and Auth::id() support

### DIFF
--- a/src/Traits/CanImpersonate.php
+++ b/src/Traits/CanImpersonate.php
@@ -2,12 +2,21 @@
 
 namespace Bizhub\Impersonate\Traits;
 
+use Exception;
 use Session;
+use Auth;
 
 trait CanImpersonate
 {
 	public function impersonate()
     {
+        if (!$this->isImpersonating()) {
+            throw new Exception('You must stop impersonating before impersonating another user.');
+        }
+        if (!Auth::check()) {
+            throw new Exception('You must be logged in before impersonating another user.');
+        }
+        Session::put('impersonator', Auth::id());
         Session::put('impersonate', $this->id);
     }
 
@@ -19,5 +28,12 @@ trait CanImpersonate
     public function isImpersonating()
     {
         return Session::has('impersonate');
+    }
+
+    public function impersonator() {
+        if ($this->isImpersonating()) {
+            return self::find(Session::get('impersonator'));
+        }
+        return null;
     }
 }

--- a/src/Traits/CanImpersonate.php
+++ b/src/Traits/CanImpersonate.php
@@ -8,7 +8,7 @@ use Auth;
 
 trait CanImpersonate
 {
-	public function impersonate()
+    public function impersonate()
     {
         if ($this->isImpersonating()) {
             throw new Exception('You must stop impersonating before impersonating another user.');
@@ -18,10 +18,16 @@ trait CanImpersonate
         }
         Session::put('impersonator', Auth::id());
         Session::put('impersonate', $this->id);
+
+        $this->resetSessionKey( $this->id );
     }
 
     public function stopImpersonating()
     {
+        if (Session::has('impersonator')) {
+            $this->resetSessionKey( Session::get('impersonator') );
+            Session::forget('impersonator');
+        }
         Session::forget('impersonate');
     }
 
@@ -32,8 +38,20 @@ trait CanImpersonate
 
     public function impersonator() {
         if ($this->isImpersonating()) {
-            return self::find(Session::get('impersonator'));
+            return self::find( Session::get('impersonator') );
         }
         return null;
+    }
+
+    /**
+     * Sets the login session value to a new ID for compatibility with Auth::id()
+     *
+     * @param $id
+     */
+    protected function resetSessionKey($id) {
+        $session_key = Auth::getName();
+        if ($session_key) {
+            Session::put($session_key, $id);
+        }
     }
 }

--- a/src/Traits/CanImpersonate.php
+++ b/src/Traits/CanImpersonate.php
@@ -19,13 +19,13 @@ trait CanImpersonate
         Session::put('impersonator', Auth::id());
         Session::put('impersonate', $this->id);
 
-        $this->resetSessionKey( $this->id );
+        $this->resetSessionKey($this->id);
     }
 
     public function stopImpersonating()
     {
         if (Session::has('impersonator')) {
-            $this->resetSessionKey( Session::get('impersonator') );
+            $this->resetSessionKey(Session::get('impersonator'));
             Session::forget('impersonator');
         }
         Session::forget('impersonate');
@@ -36,9 +36,10 @@ trait CanImpersonate
         return Session::has('impersonate');
     }
 
-    public function impersonator() {
+    public function impersonator()
+    {
         if ($this->isImpersonating()) {
-            return self::find( Session::get('impersonator') );
+            return self::find(Session::get('impersonator'));
         }
         return null;
     }
@@ -48,7 +49,8 @@ trait CanImpersonate
      *
      * @param $id
      */
-    protected function resetSessionKey($id) {
+    protected function resetSessionKey($id)
+    {
         $session_key = Auth::getName();
         if ($session_key) {
             Session::put($session_key, $id);

--- a/src/Traits/CanImpersonate.php
+++ b/src/Traits/CanImpersonate.php
@@ -10,7 +10,7 @@ trait CanImpersonate
 {
 	public function impersonate()
     {
-        if (!$this->isImpersonating()) {
+        if ($this->isImpersonating()) {
             throw new Exception('You must stop impersonating before impersonating another user.');
         }
         if (!Auth::check()) {


### PR DESCRIPTION
I added support for impersonator tracking with a method impersonator() returning that User's model.

I also noticed in Laravel 5 that I was unable to use Auth::id() without resetting a session variable.

I've only tested this with Laravel 5.0 so far and I changed a few things to match my spec, like requiring other authentication before using this, and disallowing multiple levels of impersonation to keep impersonator in tact.  If you think this works for your package, feel free to merge it in.